### PR TITLE
Add layer docstrings

### DIFF
--- a/tutorials/image.md
+++ b/tutorials/image.md
@@ -27,7 +27,31 @@ with napari.gui_qt():
 
 Both `view_image` and `add_image` have the following doc strings:
 
-**insert formatted doc strings here**
+```python
+Parameters
+----------
+image : np.ndarray
+    Image data.
+meta : dict, optional
+    Image metadata.
+multichannel : bool, optional
+    Whether the image is multichannel. Guesses if None.
+name : str, keyword-only
+    Name of the layer.
+clim_range : list | array | None
+    Length two list or array with the default color limit range for the
+    image. If not passed will be calculated as the min and max of the
+    image. Passing a value prevents this calculation which can be
+    useful when working with very large datasets that are dynamically
+    loaded.
+**kwargs : dict
+    Parameters that will be translated to metadata.
+
+Returns
+-------
+layer : :class:`napari.layers.Image`
+    The newly-created image layer.
+```
 
 ## image data and numpy-like arrays
 

--- a/tutorials/image.md
+++ b/tutorials/image.md
@@ -49,7 +49,7 @@ clim_range : list | array | None
 
 Returns
 -------
-layer : :class:`napari.layers.Image`
+layer : napari.layers.Image
     The newly-created image layer.
 ```
 

--- a/tutorials/image.md
+++ b/tutorials/image.md
@@ -27,7 +27,7 @@ with napari.gui_qt():
 
 Both `view_image` and `add_image` have the following doc strings:
 
-```python
+```
 Parameters
 ----------
 image : np.ndarray

--- a/tutorials/labels.md
+++ b/tutorials/labels.md
@@ -47,7 +47,29 @@ with napari.gui_qt():
 
 Both `view_labels` and `add_labels` have the following doc strings:
 
-**insert formatted doc strings here**
+```
+Parameters
+----------
+image : np.ndarray
+    Image data.
+meta : dict, optional
+    Image metadata.
+multichannel : bool, optional
+    Whether the image is multichannel. Guesses if None.
+opacity : float, optional
+    Opacity of the labels, must be between 0 and 1.
+name : str, keyword-only
+    Name of the layer.
+num_colors : int, optional
+    Number of unique colors to use. Default used if not given.
+**kwargs : dict
+    Parameters that will be translated to metadata.
+
+Returns
+-------
+layer : `napari.layers.Labels`
+    The newly-created labels layer.
+```
 
 ## labels data
 

--- a/tutorials/labels.md
+++ b/tutorials/labels.md
@@ -67,7 +67,7 @@ num_colors : int, optional
 
 Returns
 -------
-layer : `napari.layers.Labels`
+layer : napari.layers.Labels
     The newly-created labels layer.
 ```
 

--- a/tutorials/points.md
+++ b/tutorials/points.md
@@ -32,25 +32,35 @@ Both `view_points` and `add_points` have the following doc strings:
 ```
 Parameters
 ----------
-image : np.ndarray
-    Image data.
-meta : dict, optional
-    Image metadata.
-multichannel : bool, optional
-    Whether the image is multichannel. Guesses if None.
-opacity : float, optional
-    Opacity of the labels, must be between 0 and 1.
-name : str, keyword-only
-    Name of the layer.
-num_colors : int, optional
-    Number of unique colors to use. Default used if not given.
-**kwargs : dict
-    Parameters that will be translated to metadata.
+coords : np.ndarray
+    Coordinates for each point.
+symbol : Symbol or {'arrow', 'clobber', 'cross', 'diamond', 'disc',
+                     'hbar', 'ring', 'square', 'star', 'tailed_arrow',
+                     'triangle_down', 'triangle_up', 'vbar', 'x'}
+    Symbol to be used as a point. If given as a string, must be one of
+    the following: arrow, clobber, cross, diamond, disc, hbar, ring,
+    square, star, tailed_arrow, triangle_down, triangle_up, vbar, x
+size : int, float, np.ndarray, list
+    Size of the point marker. If given as a scalar, all points are the same
+    size. If given as a list/array, size must be the same length as
+    coords and sets the point marker size for each point in coords
+    (element-wise). If n_dimensional is True then can be a list of
+    length dims or can be an array of shape Nxdims where N is the
+    number of points and dims is the number of dimensions
+edge_width : int, float, None
+    Width of the symbol edge in pixels.
+edge_color : Color, ColorArray
+    Color of the point marker border.
+face_color : Color, ColorArray
+    Color of the point marker body.
+n_dimensional : bool
+    If True, renders points not just in central plane but also in all
+    n-dimensions according to specified point marker size.
 
 Returns
 -------
-layer : napari.layers.Labels
-    The newly-created labels layer.
+layer : napari.layers.Points
+    The newly-created points layer.
     
 ```
 

--- a/tutorials/points.md
+++ b/tutorials/points.md
@@ -29,7 +29,30 @@ viewer.add_points(points, size=30)
 
 Both `view_points` and `add_points` have the following doc strings:
 
-**insert formatted doc strings here**
+```
+Parameters
+----------
+image : np.ndarray
+    Image data.
+meta : dict, optional
+    Image metadata.
+multichannel : bool, optional
+    Whether the image is multichannel. Guesses if None.
+opacity : float, optional
+    Opacity of the labels, must be between 0 and 1.
+name : str, keyword-only
+    Name of the layer.
+num_colors : int, optional
+    Number of unique colors to use. Default used if not given.
+**kwargs : dict
+    Parameters that will be translated to metadata.
+
+Returns
+-------
+layer : napari.layers.Labels
+    The newly-created labels layer.
+    
+```
 
 ## points data
 

--- a/tutorials/shapes.md
+++ b/tutorials/shapes.md
@@ -46,7 +46,55 @@ with napari.gui_qt():
 
 Both `view_shapes` and `add_shapes` have the following doc strings:
 
-**insert formatted doc strings here**
+```
+Parameters
+----------
+data : np.array | list
+    List of np.array of data or np.array. Each element of the list (or
+    row of a 3D np.array) corresponds to one shape. If a 2D array is
+    passed it corresponds to just a single shape.
+shape_type : string | list
+    String of shape shape_type, must be one of "{'line', 'rectangle',
+    'ellipse', 'path', 'polygon'}". If a list is supplied it must be
+    the same length as the length of `data` and each element will be
+    applied to each shape otherwise the same value will be used for all
+    shapes.
+edge_width : float | list
+    thickness of lines and edges. If a list is supplied it must be the
+    same length as the length of `data` and each element will be
+    applied to each shape otherwise the same value will be used for all
+    shapes.
+edge_color : str | tuple | list
+    If string can be any color name recognized by vispy or hex value if
+    starting with `#`. If array-like must be 1-dimensional array with 3
+    or 4 elements. If a list is supplied it must be the same length as
+    the length of `data` and each element will be applied to each shape
+    otherwise the same value will be used for all shapes.
+face_color : str | tuple | list
+    If string can be any color name recognized by vispy or hex value if
+    starting with `#`. If array-like must be 1-dimensional array with 3
+    or 4 elements. If a list is supplied it must be the same length as
+    the length of `data` and each element will be applied to each shape
+    otherwise the same value will be used for all shapes.
+opacity : float | list
+    Opacity of the shapes, must be between 0 and 1.
+z_index : int | list
+    Specifier of z order priority. Shapes with higher z order are
+    displayed ontop of others. If a list is supplied it must be the
+    same length as the length of `data` and each element will be
+    applied to each shape otherwise the same value will be used for all
+    shapes.
+ndim : int, optional
+    Dimensions of shape data. Once set cannot be changed. Defaults to
+    2.
+name : str, keyword-only
+    Name of the layer.
+
+Returns
+-------
+layer : napari.layers.Shapes
+    The newly-created shapes layer.
+```
 
 ## shapes data
 

--- a/tutorials/surface.md
+++ b/tutorials/surface.md
@@ -35,7 +35,48 @@ with napari.gui_qt():
 Both `view_surface` and `add_surface` have the following doc strings:
 
 ```
+"""
 
+Parameters
+----------
+data : 3-tuple of array
+    The first element of the tuple is an (N, D) array of vertices of
+    mesh triangles. The second is an (M, 3) array of int of indices
+    of the mesh triangles. The third element is the (N, ) array of
+    values used to color vertices.
+colormap : str, vispy.Color.Colormap, tuple, dict
+    Colormap to use for luminance images. If a string must be the name
+    of a supported colormap from vispy or matplotlib. If a tuple the
+    first value must be a string to assign as a name to a colormap and
+    the second item must be a Colormap. If a dict the key must be a
+    string to assign as a name to a colormap and the value must be a
+    Colormap.
+contrast_limits : list (2,)
+    Color limits to be used for determining the colormap bounds for
+    luminance images. If not passed is calculated as the min and max of
+    the image.
+name : str
+    Name of the layer.
+metadata : dict
+    Layer metadata.
+scale : tuple of float
+    Scale factors for the layer.
+translate : tuple of float
+    Translation values for the layer.
+opacity : float
+    Opacity of the layer visual, between 0.0 and 1.0.
+blending : str
+    One of a list of preset blending modes that determines how RGB and
+    alpha values of the layer visual get mixed. Allowed values are
+    {'opaque', 'translucent', and 'additive'}.
+visible : bool
+    Whether the layer visual is currently being displayed.
+
+Returns
+-------
+layer : napari.layers.Surface
+    The newly-created surface layer.
+"""
 ```
 
 ## surface data

--- a/tutorials/surface.md
+++ b/tutorials/surface.md
@@ -34,7 +34,9 @@ with napari.gui_qt():
 
 Both `view_surface` and `add_surface` have the following doc strings:
 
-**insert formatted doc strings here**
+```
+
+```
 
 ## surface data
 

--- a/tutorials/vectors.md
+++ b/tutorials/vectors.md
@@ -45,7 +45,29 @@ with napari.gui_qt():
 
 Both `view_vectors` and `add_vectors` have the following doc strings:
 
-**insert formatted doc strings here**
+```
+Parameters
+----------
+vectors : (N, 2, D) or (N1, N2, ..., ND, D) array
+    An (N, 2, D) array is interpreted as "coordinate-like" data and a
+    list of N vectors with start point and projections of the vector in
+    D dimensions. An (N1, N2, ..., ND, D) array is interpreted as
+    "image-like" data where there is a length D vector of the
+    projections at each pixel.
+width : int
+    width of the line in pixels
+length : float
+    multiplier on length of the line
+color : str
+    one of "get_color_names" from vispy.color
+mode : str
+    control panel mode
+
+Returns
+-------
+layer : napari.layers.Vectors
+    The newly-created vectors layer.
+```
 
 ## vectors data
 


### PR DESCRIPTION
This PR address part of #18 and adds docstrings to the layer tutorials.

Tutorials to update:

- [x] `Image`
- [x] `Labels`
- [x] `Points`
- [x] `Pyramid`
- [x] `Shapes`
- [x] `Vectors`