### PR TITLE
Use contrast_limits instead of clim_range

### DIFF
--- a/tutorials/image.md
+++ b/tutorials/image.md
@@ -38,7 +38,7 @@ multichannel : bool, optional
     Whether the image is multichannel. Guesses if None.
 name : str, keyword-only
     Name of the layer.
-clim_range : list | array | None
+contrast_limits : list | array | None
     Length two list or array with the default color limit range for the
     image. If not passed will be calculated as the min and max of the
     image. Passing a value prevents this calculation which can be


### PR DESCRIPTION
Seems ```clim_range``` has been renamed to ```contrast_limits``` as described https://ilovesymposia.com/2019/10/24/introducing-napari-a-fast-n-dimensional-image-viewer-in-python/

I also found that ```multichannel``` parameter doesn't work, but don't know if that's still supported?